### PR TITLE
✨ Add output snapshots

### DIFF
--- a/src/components/core/Form/CopyForm.tsx
+++ b/src/components/core/Form/CopyForm.tsx
@@ -1,6 +1,6 @@
 import { IconButton } from "@material-ui/core";
 import React from "react";
-import { Field } from "..";
+import { Field } from "../index.d";
 import Flex from "../../utils/Flex";
 import copy from "copy-to-clipboard";
 import { tryPasteJSON } from "../../../utils/methods";

--- a/src/components/core/Form/FieldInputs/ArrayInput.tsx
+++ b/src/components/core/Form/FieldInputs/ArrayInput.tsx
@@ -2,7 +2,7 @@ import { TextField } from "@material-ui/core";
 import { Autocomplete, createFilterOptions } from "@material-ui/lab";
 import React from "react";
 import { useLittera } from "react-littera";
-import { Field } from "../..";
+import { Field } from "../../index.d";
 
 const filter = createFilterOptions<OptionType>();
 

--- a/src/components/core/Form/FieldInputs/BooleanInput.tsx
+++ b/src/components/core/Form/FieldInputs/BooleanInput.tsx
@@ -1,7 +1,7 @@
 import { MenuItem, TextField } from "@material-ui/core";
 import React from "react";
 import { useLittera } from "react-littera";
-import { Field } from "../..";
+import { Field } from "../../index.d";
 
 const translations = {
     true: {

--- a/src/components/core/Form/FieldInputs/NumberInput.tsx
+++ b/src/components/core/Form/FieldInputs/NumberInput.tsx
@@ -1,6 +1,6 @@
 import { TextField } from "@material-ui/core";
 import React from "react";
-import { Field } from "../..";
+import { Field } from "../../index.d";
 
 const NumberInput = ({ field, onChange }: { field: Field, onChange: (event: React.ChangeEvent<HTMLInputElement>) => void }) => {
 

--- a/src/components/core/Form/FieldInputs/StringInput.tsx
+++ b/src/components/core/Form/FieldInputs/StringInput.tsx
@@ -1,6 +1,6 @@
 import { TextField } from "@material-ui/core";
 import React from "react";
-import { Field } from "../..";
+import { Field } from "../../index.d";
 
 const StringInput = ({ field, onChange }: { field: Field, onChange: (event: React.ChangeEvent<HTMLInputElement>) => void }) => {
 

--- a/src/components/core/Form/FieldInputs/index.tsx
+++ b/src/components/core/Form/FieldInputs/index.tsx
@@ -1,6 +1,6 @@
 import { Message } from "@material-ui/icons";
 import React from "react";
-import { Field } from "../..";
+import { Field } from "../../index.d";
 
 import ArrayInput from "./ArrayInput";
 import BooleanInput from "./BooleanInput";

--- a/src/components/core/Form/index.d.ts
+++ b/src/components/core/Form/index.d.ts
@@ -1,0 +1,10 @@
+import { Field } from "../index.d";
+
+export type FormProps = {
+    fields: Field[];
+    getField: (target: Field["target"]) => Field | undefined;
+    setField: (target: Field["target"], value: Field["value"]) => void;
+    addField: (label: Field["label"], type: Field["type"], initialValue?: Field["value"]) => void;
+    removeField: (target: Field["target"]) => void;
+    overwriteFields: (value: Field[]) => void;
+}

--- a/src/components/core/Form/index.tsx
+++ b/src/components/core/Form/index.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
-import { Field, FIELD_TYPE_DEFAULTS_MAP, FIELD_TYPE_ICONS } from "../index";
+import { FIELD_TYPE_DEFAULTS_MAP, FIELD_TYPE_ICONS } from "../index";
+import { Field } from "../index.d";
+import { FormProps } from "./index.d";
 import { IconButton, Tooltip, Typography } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { makeStyles } from '@material-ui/styles';
@@ -46,20 +48,14 @@ const translations = (preset: ITranslationsPreset) => ({
   array: preset.array,
 })
 
-type FormProps = { 
-  fields:   Field[];
-  getField: (target: Field["target"]) => Field | undefined;
-  setField: (target: Field["target"], value: Field["value"]) => void;
-  addField: (label: Field["label"], type: Field["type"], initialValue?: Field["value"]) => void;
-  removeField: (target: Field["target"]) => void;
-  overwriteFields: (value: Field[]) => void;
-}
-
-function Form(props: FormProps ) {
-  const [newFieldName, setNewFieldName] = useState("");
-  const [newFieldType, setNewFieldType] = useState<Field["type"]>("string");
+function Form(props: FormProps) {
   const classes = useStyles();
   const translated = useLittera(translations)
+
+  // Field addition variables.
+  const [newFieldName, setNewFieldName] = useState("");
+  const [newFieldType, setNewFieldType] = useState<Field["type"]>("string");
+
 
   const handleChange = (target: Field["target"]) => (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event?.target?.value ?? "";

--- a/src/components/core/Output/index.d.ts
+++ b/src/components/core/Output/index.d.ts
@@ -1,0 +1,10 @@
+export type OutputType = {
+    title: string;
+    content: JSON;
+}
+
+export type OutputHookReturn = {
+    readonly value: OutputType[];
+    readonly add: (value: OutputType) => void;
+    readonly remove: (index: number) => void;
+}

--- a/src/components/core/Output/index.tsx
+++ b/src/components/core/Output/index.tsx
@@ -1,48 +1,18 @@
-import { Button, Typography } from '@material-ui/core';
+import { Button, IconButton, Typography } from '@material-ui/core';
 import { makeStyles } from "@material-ui/styles";
 import React from 'react';
-import { Field } from '..';
+import { Field } from '../index.d';
+import { useOutputs } from './useOutputs';
 import copy from "copy-to-clipboard";
 import { makeJSON } from '../../../utils/methods';
 import { useLittera } from 'react-littera';
 import { useSnackbar } from 'notistack';
+import Flex from '../../utils/Flex';
+import TrashIcon from "@material-ui/icons/Delete"
 
-const useStyles = makeStyles((theme) => ({
-  pre: {
-    padding: "12px 18px",
-    backgroundColor: "#f4f4f4",
-    borderRadius: 16,
-    position: "relative",
-    overflow: "auto",
-    fontSize: "1.3rem",
-  },
-  root: { width: "30%", padding: "20px 30px", paddingTop: "32px", flex: 1, height: "100%", maxHeight: "95vh", position: "relative" }
-}))
+function Output(props: { fields: Field[] }) {
+  const { value: outputs, add: addOutput, remove: removeOutput } = useOutputs();
 
-const translations = {
-  copy: {
-    en_US: "Copy",
-    pl_PL: "Skopiuj",
-    de_DE: "Einfügen"
-  },
-  title: {
-    en_US: "Result",
-    pl_PL: "Wynik",
-    de_DE: "Ergebnis"
-  },
-  copySuccess: {
-    en_US: "JSON copied to clipboard",
-    pl_PL: "JSON skopiowany do schowka",
-    de_DE: "JSON in Zwischenablage kopiert",
-  },
-  copyError: {
-    en_US: "Couldn't copy to clipboard",
-    pl_PL: "Nie udało się skopiować do schowka",
-    de_DE: "In die Zwischenablage konnte nicht kopiert werden",
-  },
-}
-
-function Output(props: {fields: Field[]}) {
   const translated = useLittera(translations);
   const classes = useStyles();
   const { enqueueSnackbar } = useSnackbar();
@@ -62,13 +32,83 @@ function Output(props: {fields: Field[]}) {
     }
   }
 
+  const handleAddOutput = () => {
+    addOutput({ title: "New draft", content: getParsedOutput() });
+  }
+
+  const getParsedOutput = () => {
+    try {
+      return JSON.parse(JSON.stringify(makeJSON(props.fields), null, 2));
+    } catch (err) {
+      console.error(err);
+      return {};
+    }
+  }
+
   return (
     <div className={classes.root}>
       <Typography variant="h4">{translated.title}</Typography>
       <pre className={classes.pre}>{JSON.stringify(makeJSON(props.fields), null, 2)}</pre>
-      <Button variant="outlined" onClick={handleCopy}>{translated.copy}</Button>
+      <Flex justifyContent="flex-start" alignItems="center">
+        <Button variant="outlined" onClick={handleCopy}>{translated.copy}</Button>
+        <Button variant="outlined" onClick={handleAddOutput}>{translated.save}</Button>
+      </Flex>
+      <Flex width="100%" flexDirection="column-reverse" alignItems="center" justifyContent="flex-start" className={classes.outputsRoot}>
+        {
+          outputs?.map((op, index) =>
+            <div style={{ width: "100%" }}>
+              <Flex alignItems="center" justifyContent="space-between" width="100%">
+                <Typography variant="h6">{op.title}</Typography>
+                <IconButton onClick={() => removeOutput(index)}><TrashIcon /></IconButton>
+              </Flex>
+              <pre key={JSON.stringify(op.content, null, 2)} className={classes.pre}>{JSON.stringify(op.content, null, 2)}</pre>
+            </div>
+          )
+        }
+      </Flex>
     </div>
   );
+}
+
+const useStyles = makeStyles((theme) => ({
+  pre: {
+    padding: "12px 18px",
+    backgroundColor: "#f4f4f4",
+    borderRadius: 16,
+    position: "relative",
+    overflow: "auto",
+    fontSize: "1.3rem",
+  },
+  root: { width: "30%", padding: "20px 30px", paddingTop: "32px", flex: 1, height: "100%", maxHeight: "95vh", position: "relative" },
+  outputsRoot: { position: "relative", marginTop: "5%", maxHeight: "100%", overflowY: "scroll" }
+}))
+
+const translations = {
+  copy: {
+    en_US: "Copy",
+    pl_PL: "Skopiuj",
+    de_DE: "Einfügen"
+  },
+  save: {
+    en_US: "Save",
+    pl_PL: "Zapisz",
+    de_DE: "Speichern"
+  },
+  title: {
+    en_US: "Result",
+    pl_PL: "Wynik",
+    de_DE: "Ergebnis"
+  },
+  copySuccess: {
+    en_US: "JSON copied to clipboard",
+    pl_PL: "JSON skopiowany do schowka",
+    de_DE: "JSON in Zwischenablage kopiert",
+  },
+  copyError: {
+    en_US: "Couldn't copy to clipboard",
+    pl_PL: "Nie udało się skopiować do schowka",
+    de_DE: "In die Zwischenablage konnte nicht kopiert werden",
+  },
 }
 
 export default Output;

--- a/src/components/core/Output/useOutputs.tsx
+++ b/src/components/core/Output/useOutputs.tsx
@@ -1,0 +1,37 @@
+import { useRef, useState } from 'react';
+import { OutputType, OutputHookReturn } from './index.d';
+
+export const useOutputs = () => {
+    const [outputs, setOutputs] = useState<OutputType[]>([]);
+    const ref = useRef<OutputHookReturn>(null as unknown as OutputHookReturn);
+
+
+    console.log("Outputs =>", outputs);
+
+    if (ref.current === null) {
+        const add = (value: OutputType) => {
+            console.log("add", value);
+            setOutputs(_outputs => {
+                _outputs.push(value);
+                return [..._outputs];
+            })
+        }
+        const remove = (index: number) => {
+            console.log("remove", index);
+            setOutputs(_outputs => {
+                _outputs.splice(index, 1);
+                return [..._outputs];
+            })
+        }
+
+        ref.current = {
+            value: outputs,
+            add,
+            remove
+        };
+    }
+    // @ts-ignore
+    ref.current.value = outputs;
+
+    return ref.current;
+};

--- a/src/components/core/index.d.ts
+++ b/src/components/core/index.d.ts
@@ -1,0 +1,7 @@
+export type Field = { value: FieldType, target: string, label: string, type: FieldTypeLiteral }
+export type FieldType = string | number | boolean | FieldType[];
+export type FieldTypeLiteral = "string" | "number" | "boolean" | "array";
+
+export type FieldTypeOption = { value: FieldTypeLiteral, label: string }
+export type FieldTypeIcons = { [key in FieldTypeLiteral]: JSX.Element }
+export type FieldTypeDefault = { [key in FieldTypeLiteral]: FieldType }

--- a/src/components/core/index.tsx
+++ b/src/components/core/index.tsx
@@ -10,6 +10,8 @@ import NumberIcon from "@material-ui/icons/Dialpad";
 import BooleanIcon from "@material-ui/icons/Cached";
 import ArrayIcon from "@material-ui/icons/Reorder";
 
+import { Field, FieldTypeDefault, FieldTypeIcons, FieldTypeOption } from "./index.d";
+
 const useStyles = makeStyles((theme) => ({
     root: {
         position: "relative",
@@ -17,9 +19,7 @@ const useStyles = makeStyles((theme) => ({
     }
 }))
 
-export type Field = { value: FieldType, target: string, label: string, type: FieldTypeLiteral }
-export type FieldType = string | number | boolean | FieldType[];
-export type FieldTypeLiteral = "string" | "number" | "boolean" | "array";
+
 
 const INITIAL_STATE: Field[] = [
     { value: "Foo", target: "first_name", label: "First name", type: "string" },
@@ -30,7 +30,6 @@ const INITIAL_STATE: Field[] = [
     { value: ["01", "02"], target: "labs", label: "Labs", type: "array" },
 ]
 
-type FieldTypeOption = { value: FieldTypeLiteral, label: string }
 export const FIELD_TYPE_OPTIONS: FieldTypeOption[] = [
     {
         value: 'string',
@@ -54,7 +53,6 @@ const defaultTypeIconProps = {
     size: "16px",
     style: { marginRight: "10px" }
 }
-type FieldTypeIcons = { [key in FieldTypeLiteral]: JSX.Element }
 export const FIELD_TYPE_ICONS: FieldTypeIcons = {
     string: <StringIcon     {...defaultTypeIconProps} />,
     number: <NumberIcon     {...defaultTypeIconProps} />,
@@ -62,7 +60,6 @@ export const FIELD_TYPE_ICONS: FieldTypeIcons = {
     array: <ArrayIcon      {...defaultTypeIconProps} />
 }
 
-type FieldTypeDefault = { [key in FieldTypeLiteral]: FieldType }
 export const FIELD_TYPE_DEFAULTS_MAP: FieldTypeDefault = {
     boolean: false,
     number: 0,

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,0 +1,3 @@
+import { useState } from "react";
+
+export const useSignal = () => useState<any>()[1];

--- a/src/utils/methods.ts
+++ b/src/utils/methods.ts
@@ -1,4 +1,4 @@
-import { Field } from "../components/core";
+import { Field } from "../components/core/index.d";
 
 export function makeTarget(label: Field["label"]) {
     return label.toLowerCase().replace(/ /g, "_"); // eg. First name => first_name


### PR DESCRIPTION
This feature allows you to save a version of your JSON output. It's useful when you want to make changes but also want to keep the previous version without the need to copy and save it at your own. 

⚠️ Work still in progress:
- Add snapshot title edition.
- Add revert button or make snapshots editable.
- Adjust margins and styling overall.
- Cleanup code.

Example:
![screen-capture (8)](https://user-images.githubusercontent.com/7634871/93482418-fccf1480-f8ff-11ea-8d2c-112234fd0128.gif)